### PR TITLE
Simplify styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@
       Let's look at some actual facts and stats, shall we?
     </p>
     <ul>
-      <li>According to a <a href="https://www.ars.usda.gov/ARSUserFiles/80400530/pdf/DBrief/11_consumption_of_pizza_0710.pdf">2014 US Department of Agriculture report<a/>, 1 in 8 Americans consume pizza on any given day.</li>
+      <li>According to a <a href="https://www.ars.usda.gov/ARSUserFiles/80400530/pdf/DBrief/11_consumption_of_pizza_0710.pdf">2014 US Department of Agriculture report</a>, 1 in 8 Americans consume pizza on any given day.</li>
       <li>According to the <a href="https://www.cdc.gov/ncbddd/disabilityandhealth/infographic-disability-impacts-all.html">US Center for Disease Control and Prevention,</a> 1 in 4 Americans live with a disability, 4.6% of American adults have a visual impairment and 5.9% have a hearing impairment. That works out to being 6.4 million Americans who are impacted by inaccessible web content.</li>
       <li>A <a href="https://webaim.org/projects/million/">recent study by WebAim</a> looked at the top 1 million home pages on the internet and analyzed how well they conformed to the Web Content Accessibility Guidelines by scanning for errors with the WAVE browser Extension. They found that 97.8% of home pages had errors that the browser extension could detect. WebAim estimated that less than 1% of the web pages actually conform to accessibility guidelines.</li>
       <li>Version 2.0 of the Web Content Accessibility Guidelines (the one that everyone is supposed to follow) was published in 2008. I think it's fair to say that 11.5 years should be long enough for companies like Dominos to get with the program.</li>

--- a/index.html
+++ b/index.html
@@ -25,60 +25,21 @@
     main a:visited,
     main a:focus,
     main a:active {
-      color: white;
+      color: transparent;
     }
 
     /* Moving your mouse around to try and find something is futile */
-    main a,
-    main p,
-    main h1,
-    main h2,
-    main h3,
-    main h4,
-    main h5,
-    main h6,
-    main ul,
-    main li,
-    main {
+    main * {
       cursor: default;
+      pointer-events: none;
     }
 
     /* Make it so that highlighting the page also doesn't do anything */
-    main p::moz-selection {
-      background: white;
+    main *::moz-selection {
+      background: transparent;
     }
-    main p::selection {
-      background: white;
-    }
-    main h1::moz-selection {
-      background: white;
-    }
-    main h1::selection {
-      background: white;
-    }
-    main h2::moz-selection {
-      background: white;
-    }
-    main h2::selection {
-      background: white;
-    }
-    main a::moz-selection {
-      background: white;
-    }
-    main a::selection {
-      background: white;
-    }
-    main ul li::moz-selection {
-      background: white;
-    }
-    main ul li::selection {
-      background: white;
-    }
-    main em::moz-selection {
-      background: white;
-    }
-    main em::selection {
-      background: white;
+    main *::selection {
+      background: transparent;
     }
   </style>
 </head>


### PR DESCRIPTION
I simplified some selectors to use `*` within `main` to make future maintenance easier. I also set the colour of things within `main` to be transparent, and disabled pointer-events in `main` as well.

I have other ideas on how to make this super inaccessible to sighted folk, but I might do that in a future pull request! 😆 